### PR TITLE
refactor(front): create a component to manage the product form

### DIFF
--- a/frontend/src/app/product/edit-product/edit-product.component.html
+++ b/frontend/src/app/product/edit-product/edit-product.component.html
@@ -20,65 +20,11 @@
           <span>{{ this.errorMessage }}</span>
         </div>
       }
-      <form [formGroup]="productForm" (ngSubmit)="onSubmit()">
-        <div class="form-control">
-          <label class="form-control">
-            <div class="label">
-              <span class="label-text">Designation*</span>
-            </div>
-            <textarea
-              [class.input-error]="
-                !productForm.controls['designation'].untouched &&
-                productForm.controls['designation'].invalid
-              "
-              class="textarea textarea-bordered"
-              formControlName="designation"
-              rows="3"
-              placeholder="Waterproof smartwatch..."
-            ></textarea>
-          </label>
-        </div>
-        <div class="form-control">
-          <label class="form-control">
-            <div class="label">
-              <span class="label-text">Description</span>
-            </div>
-            <textarea
-              [class.input-error]="
-                !productForm.controls['designation'].untouched &&
-                productForm.controls['designation'].invalid
-              "
-              class="textarea textarea-bordered"
-              formControlName="description"
-              rows="5"
-              placeholder="A beautiful watch..."
-            ></textarea>
-          </label>
-        </div>
-        <div class="form-control">
-          <label class="label">
-            <span class="label-text">Category</span>
-          </label>
-
-          <select
-            class="select select-bordered w-full"
-            formControlName="category"
-          >
-            <option disabled value="">Select a category</option>
-            @for (
-              category of productService.categoryList();
-              track category.id
-            ) {
-              <option value="{{ category.id }}">{{ category.name }}</option>
-            }
-          </select>
-        </div>
-        <div class="form-control mt-6">
-          <button [disabled]="!productForm.valid" class="btn btn-primary">
-            Submit
-          </button>
-        </div>
-      </form>
+      <app-product-form
+        [categories]="productService.categoryList()"
+        [(product)]="productFormValues"
+        (onSubmit)="onSubmit()"
+      />
     </div>
   </div>
 </div>

--- a/frontend/src/app/product/product-form/product-form.component.html
+++ b/frontend/src/app/product/product-form/product-form.component.html
@@ -1,0 +1,62 @@
+<form [formGroup]="productForm" (ngSubmit)="onSubmit.emit()">
+  <div class="form-control">
+    <label class="form-control">
+      <div class="label">
+        <span class="label-text">Designation*</span>
+      </div>
+      <textarea
+        [class.textarea-error]="
+          !productForm.controls['designation'].untouched &&
+          productForm.controls['designation'].invalid
+        "
+        class="textarea textarea-bordered"
+        formControlName="designation"
+        rows="3"
+        placeholder="Waterproof smartwatch..."
+      ></textarea>
+    </label>
+  </div>
+  <div class="form-control">
+    <label class="form-control">
+      <div class="label">
+        <span class="label-text">Description</span>
+      </div>
+      <textarea
+        [class.textarea-error]="
+          !productForm.controls['description'].untouched &&
+          productForm.controls['description'].invalid
+        "
+        class="textarea textarea-bordered"
+        formControlName="description"
+        rows="5"
+        placeholder="A beautiful watch..."
+      ></textarea>
+    </label>
+  </div>
+  @if (categories() !== undefined) {
+    <div class="form-control">
+      <label class="label">
+        <span class="label-text">Category</span>
+      </label>
+
+      <select
+        [class.select-error]="
+          !productForm.controls['category'].untouched &&
+          productForm.controls['category'].invalid
+        "
+        class="select select-bordered w-full"
+        formControlName="category"
+      >
+        <option disabled value="-1">Select a category</option>
+        @for (category of categories(); track category.id) {
+          <option value="{{ category.id }}">{{ category.name }}</option>
+        }
+      </select>
+    </div>
+  }
+  <div class="form-control mt-6">
+    <button [disabled]="!productForm.valid" class="btn btn-primary">
+      Submit
+    </button>
+  </div>
+</form>

--- a/frontend/src/app/product/product-form/product-form.component.spec.ts
+++ b/frontend/src/app/product/product-form/product-form.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ProductFormComponent } from './product-form.component';
+
+describe('ProductFormComponent', () => {
+  let component: ProductFormComponent;
+  let fixture: ComponentFixture<ProductFormComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ProductFormComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(ProductFormComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/frontend/src/app/product/product-form/product-form.component.ts
+++ b/frontend/src/app/product/product-form/product-form.component.ts
@@ -1,0 +1,115 @@
+import { Component, input, model, output } from "@angular/core";
+import {
+  FormControl,
+  FormGroup,
+  ReactiveFormsModule,
+  Validators,
+} from "@angular/forms";
+import { Category, ProductForm } from "../product.model";
+
+@Component({
+  selector: "app-product-form",
+  imports: [ReactiveFormsModule],
+  templateUrl: "./product-form.component.html",
+  styles: ``,
+})
+export class ProductFormComponent {
+  // Categories to add in the selector
+  categories = input<Category[]>();
+  // Callback triggered when the user clicks on Submit
+  onSubmit = output<void>();
+  // Two-way data binding to hold the content of the form
+  product = model<ProductForm>();
+  // Form group to control the form
+  productForm = new FormGroup({
+    designation: new FormControl(this.product()?.designation ?? "", [
+      Validators.required,
+      Validators.maxLength(256),
+    ]),
+    description: new FormControl(""),
+    category: new FormControl("", Validators.required),
+  });
+  // Subscription
+  designationSubscription: any;
+  descriptionSubscription: any;
+  categorySubscription: any;
+
+  /**
+   * Initializes a new instance of the constructor and sets up the necessary form controls.
+   * Calls the `subscribeFormControls` method as part of the initialization process.
+   * @return {Object} The instance of the object created by the constructor.
+   */
+  constructor() {
+    this.subscribeFormControls();
+  }
+
+  // noinspection JSUnusedGlobalSymbols
+  /**
+   * Lifecycle hook that is called when any data-bound property of a directive changes.
+   * This method is used to update the form controls with the current product values whenever changes are detected.
+   * It first checks if the product is defined, and if so, updates the controls for designation, description, and category
+   * with the product's current values. The category value is converted to a string if it exists; otherwise, it defaults to "-1".
+   * It also manages form control subscriptions by unsubscribing and re-subscribing them during the update process.
+   *
+   * @return {void} No return value.
+   */
+  ngOnChanges(): void {
+    if (this.product() === undefined) return;
+    this.unsubscribeFormControls();
+    this.productForm.controls["designation"].setValue(
+      this.product()?.designation ?? "",
+    );
+    this.productForm.controls["description"].setValue(
+      this.product()?.description ?? "",
+    );
+    this.productForm.controls["category"].setValue(
+      (this.product()?.categoryId ?? -1).toString(),
+    );
+    this.subscribeFormControls();
+  }
+
+  /**
+   * Subscribes to the value changes of form controls within the product form and updates the product state accordingly.
+   * Each control's value change triggers an update to the product's corresponding property.
+   * It manages subscriptions for designation, description, and category form controls.
+   *
+   * @return {void} Does not return any value.
+   */
+  subscribeFormControls(): void {
+    // Subscribe to all control changes to propagate the new values to the parent component
+    this.designationSubscription = this.productForm.controls[
+      "designation"
+    ].valueChanges.subscribe((value) => {
+      this.product.set({ ...this.product(), designation: value ?? "" });
+    });
+    this.descriptionSubscription = this.productForm.controls[
+      "description"
+    ].valueChanges.subscribe((value) => {
+      this.product.set({ ...this.product(), description: value ?? "" });
+    });
+    this.categorySubscription = this.productForm.controls[
+      "category"
+    ].valueChanges.subscribe((value) => {
+      this.product.set({
+        ...this.product(),
+        categoryId: Number(value) ?? undefined,
+      });
+    });
+  }
+
+  /**
+   * Unsubscribes from the form control subscriptions, if they exist.
+   *
+   * This method is responsible for cleaning up resources by terminating
+   * any active subscriptions related to form controls. Specifically, it
+   * will unsubscribe from `designationSubscription`, `descriptionSubscription`,
+   * and `categorySubscription` if these subscriptions are present.
+   *
+   * @return {void} Does not return any value.
+   */
+  unsubscribeFormControls() {
+    this.designationSubscription?.unsubscribe();
+    this.descriptionSubscription?.unsubscribe();
+    this.categorySubscription?.unsubscribe();
+  }
+}

--- a/frontend/src/app/product/product-management/product-management.component.html
+++ b/frontend/src/app/product/product-management/product-management.component.html
@@ -60,7 +60,7 @@
                   }}</span>
                 </div>
               </td>
-              <td>{{ product.category?.name }}</td>
+              <td>{{ product.category.name }}</td>
               <td class="flex gap-2">
                 <div class="tooltip" data-tip="Edit user">
                   <button

--- a/frontend/src/app/product/product.model.ts
+++ b/frontend/src/app/product/product.model.ts
@@ -17,6 +17,27 @@ export interface Product {
 }
 
 /**
+ * Represents the input values for product-related data.
+ *
+ * This interface is used to define the structure of product data that is submitted
+ * to or received from a form. It includes basic product information such as the
+ * product's ID, designation, description, and associated category ID. All fields
+ * are optional, allowing partial updates or submissions as needed.
+ *
+ * Properties:
+ * @property {number} [id] - The unique identifier for the product.
+ * @property {string} [designation] - The title or name of the product.
+ * @property {string} [description] - Detailed information about the product.
+ * @property {number} [categoryId] - The identifier for the category to which the product belongs.
+ */
+export interface ProductForm {
+  id?: number;
+  designation?: string;
+  description?: string;
+  categoryId?: number;
+}
+
+/**
  *  Defines the content of the payload expected to send a patch request
  *  to update a product on the API.
  */


### PR DESCRIPTION
- This component is currently used in edit-product, but it'll also be used in the prediction view.
- Fix an issue with the form where the fields would not be highlighted in red when there was validation errors.
- Fix Angular warning regarding a null checking for a variable that can't be null anymore.